### PR TITLE
Link footer to about and contact pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -162,19 +162,27 @@ def index():
     return render_template('index.html', services=services)
 
 
-@app.route('/contact', methods=['POST'])
-def contact():
-    """Handle contact form submissions via AJAX."""
-    data = request.form
-    name = data.get('name')
-    email = data.get('email')
-    message = data.get('message')
-    if not all([name, email, message]):
-        return jsonify({'status': 'error', 'message': 'All fields are required.'}), 400
-    contact = Contact(name=name, email=email, message=message)
-    db.session.add(contact)
-    db.session.commit()
-    return jsonify({'status': 'success'})
+@app.route('/about')
+def about_page():
+    """Serve the standalone about page."""
+    return render_template('about.html')
+
+
+@app.route('/contact', methods=['GET', 'POST'])
+def contact_page():
+    """Render the contact page and handle AJAX form submissions."""
+    if request.method == 'POST':
+        data = request.form
+        name = data.get('name')
+        email = data.get('email')
+        message = data.get('message')
+        if not all([name, email, message]):
+            return jsonify({'status': 'error', 'message': 'All fields are required.'}), 400
+        contact = Contact(name=name, email=email, message=message)
+        db.session.add(contact)
+        db.session.commit()
+        return jsonify({'status': 'success'})
+    return render_template('contact.html')
 
 
 @app.route('/order', methods=['POST'])

--- a/templates/base.html
+++ b/templates/base.html
@@ -66,8 +66,8 @@
       <div class="footer-column">
         <h4>Company</h4>
         <ul>
-          <li><a href="#about">About</a></li>
-          <li><a href="#contact">Contact</a></li>
+          <li><a href="{{ url_for('about_page') }}">About</a></li>
+          <li><a href="{{ url_for('contact_page') }}">Contact</a></li>
         </ul>
       </div>
       <div class="footer-column">


### PR DESCRIPTION
## Summary
- Link footer "About" and "Contact" items to dedicated routes
- Add about and contact page views, with contact page handling form submissions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab03266060832ab87c9f545f9a9977